### PR TITLE
Use older Python syntax for regex groups.

### DIFF
--- a/SendToPasteBin.py
+++ b/SendToPasteBin.py
@@ -155,7 +155,7 @@ class PasteBinApiCall(threading.Thread):
         paste_key = re.match(url_regex, response, flags=re.IGNORECASE)
 
         if self.settings.get("paste_url_type") == "raw":
-            response = ROOT_URL + "/raw/" + paste_key[2]
+            response = ROOT_URL + "/raw/" + paste_key.group(2)
 
         sublime.set_clipboard(response)
         sublime.status_message('PasteBin URL copied to clipboard: ' + response)


### PR DESCRIPTION
Signed-off-by: Ryan McQuen <rmcquen@funko.com>